### PR TITLE
remove `browser`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "Ivan Voischev <voischev.ivan@ya.ru>",
   "license": "MIT",
   "main": "lib/index.js",
-  "browser": "lib/browser.min.js",
   "files": [
     "lib"
   ],


### PR DESCRIPTION
This makes the module or the render function is undefined after bundled with webpack or other bundlers, I think remove `browser` will be better for modularized frontend development. If you do not agree, just close the request. Sorry for my poor English.